### PR TITLE
Respect Atom's editor preferences for preferred tab and line length

### DIFF
--- a/lib/format.coffee
+++ b/lib/format.coffee
@@ -25,7 +25,10 @@ module.exports =
 
       setTimeout destroyer, 1500
 
-
   formatJavascript: (editor) ->
-    opts = {}
+    settings = atom.config.getSettings().editor
+    opts = {
+      indent_size: settings.tabLength,
+      wrap_line_length: settings.preferredLineLength
+    }
     editor.setText(jsbeautify(editor.getText(), opts))


### PR DESCRIPTION
Hey there, small patch to pass indent_size and wrap_line_length parameters to js-beautify based on Atom's editor settings.

From the README it's implied that eventually you'll want the plugin to have its own settings, but this is a nice stop-gap measure to have the plugin respect settings that are already exposed via the editor settings panel.
