### PR TITLE
Settings customization with defaults from the Sublime jsformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,22 @@ Javascript + json formatting/beautification for the Atom text editor.
 
 #### Warning
 This project is insanely pre-alpha.
-So no, you can't customize settings yet.
+
+#### Settings
+JsFormat uses whatever tab/indent settings are configured with the standard ```Tab Length``` Atom settings. The ```Preferred Line Length``` Atom setting is only respected when the ```Soft Wrap At Preferred Line Length``` Atom setting is enabled.
+
+The following **JsBeautifier** settings are available through the JsFormat settings panel (defaults shown below). Check out the official [jsbeautifier documentation](https://github.com/einars/js-beautify#options) for more details on the options:
+
+* `indent_with_tabs`: false,
+* `max_preserve_newlines`: 4,
+* `preserve_newlines`: true,
+* `space_in_paren`: false,
+* `jslint_happy`: false,
+* `brace_style`: "collapse",
+* `keep_array_indentation`: false,
+* `keep_function_indentation`: false,
+* `space_before_conditional`: true,
+* `eval_code`: false,
+* `unescape_strings`: false,
+* `break_chained_methods`: false,
+* `e4x`: false

--- a/lib/format.coffee
+++ b/lib/format.coffee
@@ -4,6 +4,21 @@ path = require 'path'
 jsbeautify = (require 'js-beautify').js_beautify
 
 module.exports =
+  configDefaults:
+    indent_with_tabs: false,
+    max_preserve_newlines: 4,
+    preserve_newlines: true,
+    space_in_paren: false,
+    jslint_happy: false,
+    brace_style: "collapse",
+    keep_array_indentation: false,
+    keep_function_indentation: false,
+    space_before_conditional: true,
+    eval_code: false,
+    unescape_strings: false,
+    break_chained_methods: false,
+    e4x: false
+
   activate: (state) ->
     atom.workspaceView.command "jsformat:format", => @format(state)
 
@@ -31,4 +46,8 @@ module.exports =
       indent_size: settings.tabLength,
       wrap_line_length: settings.preferredLineLength
     }
+
+    for configKey, defaultValue of @configDefaults
+      opts[configKey] = atom.config.get('jsformat.' + configKey) ? defaultValue
+
     editor.setText(jsbeautify(editor.getText(), opts))


### PR DESCRIPTION
Hey again, one more small one that adds basic jsformat options to the settings panel for the plugin.

Atom has a rather limited mechanism for specifying how settings should be presented so limited fields like brace_style have no validation at the moment.

Fixes #4 (although doesn't add format on save as was suggested in a comment, that should be a separate issue)

Also #5 is now fixed.
