### PR TITLE
Format Selection and Grammar Detection

### DIFF
--- a/lib/format.coffee
+++ b/lib/format.coffee
@@ -49,4 +49,13 @@ module.exports =
     for configKey, defaultValue of @configDefaults
       opts[configKey] = atom.config.get('jsformat.' + configKey) ? defaultValue
 
-    editor.setText(jsbeautify(editor.getText(), opts))
+    if @selectionsAreEmpty editor
+      editor.setText(jsbeautify(editor.getText(), opts))
+    else
+      for selection in editor.getSelections()
+        selection.insertText(jsbeautify(selection.getText(), opts), {select:true})
+
+  selectionsAreEmpty: (editor) ->
+    for selection in editor.getSelections()
+      return false unless selection.isEmpty()
+    true


### PR DESCRIPTION
Hi again,

I've repackaged my previous pull request without 'format on save'. This one adds grammar detection instead of sniffing the file extension from the title and also adds formatting of the current selection(s).
