### PR TITLE
Made formatJavascript take the active editor's tablength

### DIFF
--- a/lib/format.coffee
+++ b/lib/format.coffee
@@ -42,7 +42,7 @@ module.exports =
   formatJavascript: (editor) ->
     settings = atom.config.getSettings().editor
     opts = {
-      indent_size: settings.tabLength,
+      indent_size: editor.getTabLength(),
       wrap_line_length: settings.preferredLineLength
     }
 


### PR DESCRIPTION
Before, the global preference tab length was used, which caused
some annoyances when a user would set tab length by using init
scripts or had changed them otherwise separate from the global
config.
