### PR TITLE
Create CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# 0.3.2
+
+Fixed issue where closing a file would cause Atom to freeze because of extra subscribers from format on save
+
+# 0.3.0
+
+Format on save functionality added
+
+# 0.2.1
+
+Uses editor's tablength to format text
+
+# 0.2.0
+
+Added the ability to format currently selected text
+
+Now using file's grammar (which can be manually set by user) to decide whether or not to format the selection/file
+
+# 0.1.0
+
+Added a lot more settings and configuration options
+
+# 0.0.6
+
+Fixed issue when no editors are open
+Fixed not supported view message
+
+# 0.0.5
+
+Improved the readme
+
+# 0.0.4
+
+No changes, test publish
+
+# 0.0.3
+
+Fixed package.json formatting
+
+# 0.0.2
+
+Added keywords to package.json to make package easier to find
+
+# 0.0.1
+
+Initial JSFormat plugin


### PR DESCRIPTION
Users can now see directly from atom what each new version brings.

@jdc0589 you can merge this in and release it whenever, it's just a docs PR.
