### PR TITLE
Fixes jdc0589/jsformat-atom#48 deprecated calls

### DIFF
--- a/lib/not-supported-view.coffee
+++ b/lib/not-supported-view.coffee
@@ -1,4 +1,4 @@
-{View} = require 'atom'
+{View} = require 'atom-space-pen-views'
 path = require 'path'
 
 module.exports =

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "beautify",
     "prettify"
   ],
-  "activationEvents": [],
+  "activationCommands": [],
   "repository": "https://github.com/jdc0589/jsformat-atom",
   "license": "MIT",
   "engines": {
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "event-kit": "~0.8.1",
-    "js-beautify": "~1.5.4"
+    "js-beautify": "~1.5.4",
+    "atom-space-pen-views": "~2.0.3"
   }
 }


### PR DESCRIPTION
Updates to remove two deprecated messages, one for `{View}` as mentioned in #48 and replacing `"activationEvents"` with `"activationCommands"` in package.json.