### PR TITLE
fix for soft to hard tab conversion

### DIFF
--- a/lib/format.coffee
+++ b/lib/format.coffee
@@ -76,7 +76,7 @@ module.exports =
     editorSettings = atom.config.get('editor')
 
     opts = atom.config.get('jsformat')
-    opts.indent_with_tabs = editor.getSoftTabs()
+    opts.indent_with_tabs = !editor.getSoftTabs()
     opts.indent_size = editorSettings.tabLength
     opts.wrap_line_length = editorSettings.preferredLineLength
 


### PR DESCRIPTION
Line #79 of `format.coffee` assigns the result of `.getSoftTabs()` to the `indent_with_tabs` option. The return value of [textEditor.getSoftTabs()](https://atom.io/docs/api/v0.192.0/TextEditor#instance-getSoftTabs) is `true` when soft tabs are set in the instance. When soft tabs are being used in the editor, this results in the options being set to indent with tabs instead.

With this commit `indent_with_tabs` is now correctly set as true when the editor is using hard tabs and false when the editor is using soft tabs. I've tested this change in both instances and it now behaves as expected.