### PR TITLE
Fix deprecated: The context menu CSON format has changed.

### DIFF
--- a/menus/format.cson
+++ b/menus/format.cson
@@ -1,7 +1,11 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  '.overlayer':
-      'Enable JSFormat': 'jsformat:format'
+  '.overlayer': [
+    {
+      'label': 'Enable JSFormat'
+      'command': 'jsformat:format'
+    }
+  ]
 
 'menu': [
   {


### PR DESCRIPTION
This PR fix the deprecation message:
The context menu CSON format has changed. Please see https://atom.io/docs/api/latest/ContextMenuManager#context-menu-cson-format for more info.