### PR TITLE
Changed keybinding to be more specific

### DIFF
--- a/keymaps/format.cson
+++ b/keymaps/format.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'atom-workspace':
+'atom-workspace atom-text-editor:not([mini])':
   'ctrl-alt-f': 'jsformat:format'


### PR DESCRIPTION
Changed keybinding to be as specific as the conflicting Atom core keybinding.

Note that I haven't tested this (I don't know how yet). I'm using this binding in my local keymap.cson and it works there.